### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/simpleashwani006/69bfda5b-77db-4d11-ad82-8697e6f227af/7ef50276-85c3-4b0c-868f-2aabdf4107c1/_apis/work/boardbadge/258d05c7-e7ba-4654-8664-e83d2c8ab074)](https://dev.azure.com/simpleashwani006/69bfda5b-77db-4d11-ad82-8697e6f227af/_boards/board/t/7ef50276-85c3-4b0c-868f-2aabdf4107c1/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/simpleashwani006/69bfda5b-77db-4d11-ad82-8697e6f227af/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.